### PR TITLE
Increase gallery tile and zoomed image sizes, change zoomed avatar border color

### DIFF
--- a/src/components/Gallery/ContributorGalleryCell.tsx
+++ b/src/components/Gallery/ContributorGalleryCell.tsx
@@ -32,8 +32,8 @@ const Cell = styled.div<ThemeProps>`
 `;
 
 const FittedImage = styled.img<MatrixCell & ThemeProps>`
-  border: ${({ isActive }) => (isActive ? 5 : 0)}px solid
-    ${({ theme: { primaryColor } }) => primaryColor};
+  border: ${({ isActive }) => (isActive ? 2 : 0)}px solid
+    ${({ theme: { specialColor } }) => specialColor};
   box-sizing: content-box;
   max-width: 100%;
   position: relative;

--- a/src/components/theme.ts
+++ b/src/components/theme.ts
@@ -28,9 +28,9 @@ interface Theme {
 
 export default {
   bonusColor: "orange",
-  borderStyle: "0.5px solid #666",
-  cellSize: "30px",
+  borderStyle: "0.25px solid #666",
+  cellSize: "60px",
   primaryColor: "#9082CD",
   secondaryColor: "#666",
-  specialColor: "gold",
+  specialColor: "green",
 } as Theme;


### PR DESCRIPTION
Fixes #2

Increase gallery tile and zoomed image sizes, and change the active gallery cell border color to green and make it thinner.

* **Gallery Tile and Zoomed Image Sizes**
  - Update `cellSize` to "60px" in `src/components/theme.ts` to double the size of gallery tiles.
  
* **Active Gallery Cell Border Color and Thickness**
  - Update `borderStyle` to "0.25px solid #666" in `src/components/theme.ts` to make the border thinner.
  - Add `specialColor` with value "green" in `src/components/theme.ts` for the active gallery cell border color.
  - Update `border` property of `FittedImage` in `src/components/Gallery/ContributorGalleryCell.tsx` to use `specialColor` for active cells.
  - Update `border` thickness of `FittedImage` in `src/components/Gallery/ContributorGalleryCell.tsx` to 2px for active cells.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/latekpro/contributor-gallery/pull/4?shareId=0793f57d-facf-4f7f-a3dc-309b6c479ac5).