### PR TITLE
Show GitHub handle when a gallery cell is active in the grid

### DIFF
--- a/src/components/Gallery/ContributorGalleryCell.tsx
+++ b/src/components/Gallery/ContributorGalleryCell.tsx
@@ -11,10 +11,13 @@ export default function ContributorGalleryCell({
   cell,
 }: ContributorGalleryCellProps): JSX.Element {
   const cellContent = cell.contributor ? (
-    <FittedImage
-      src={cell.contributor.avatar_url}
-      {...cell}
-    />
+    <>
+      <FittedImage
+        src={cell.contributor.avatar_url}
+        {...cell}
+      />
+      {cell.isActive && <LoginText>{cell.contributor.login}</LoginText>}
+    </>
   ) : null;
 
   return <Cell>{cellContent}</Cell>;
@@ -41,4 +44,15 @@ const FittedImage = styled.img<MatrixCell & ThemeProps>`
   transition: transform 2s ease;
   z-index: ${({ isActive }) =>
     isActive ? 10 : 1};
+`;
+
+const LoginText = styled.div<ThemeProps>`
+  font-size: ${cellSize};
+  text-shadow: 1px 1px 2px black;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 11;
+  color: white;
 `;

--- a/src/model/contributorsMatrix.ts
+++ b/src/model/contributorsMatrix.ts
@@ -6,15 +6,15 @@ const ROWS = 20;
 export interface MatrixCell {
   isActive?: boolean;
   contributor: Contributor | null;
+  login?: string | null;
 }
 
 const matrix: MatrixCell[] = [];
 for (let x = 0; x < COLUMNS; x++) {
   for (let y = 0; y < ROWS; y++) {
-    // const cellNumber = y + x * ROWS + 1;
-
     const contributor = signatures.shift() || null;
-    matrix.push({ contributor });
+    const login = contributor ? contributor.login : null;
+    matrix.push({ contributor, login });
   }
 }
 


### PR DESCRIPTION
Fixes #1

Add GitHub handle display for active gallery cells.

* Add `LoginText` styled component in `src/components/Gallery/ContributorGalleryCell.tsx` to display the GitHub handle.
* Conditionally display `LoginText` when the cell is active.
* Set font size, text shadow, centering, and z-index for `LoginText`.
* Add `login` property to `MatrixCell` interface in `src/model/contributorsMatrix.ts`.
* Populate `login` property with the contributor's GitHub handle.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/latekpro/contributor-gallery/pull/5?shareId=8aff8792-5b1e-404e-aa0d-061fcadab515).